### PR TITLE
Check if git directory is empty before updating

### DIFF
--- a/memeinator/src/lib.rs
+++ b/memeinator/src/lib.rs
@@ -317,7 +317,7 @@ impl MemeSource {
         let path = match self {
             MemeSource::GitUrl { url, alias } => {
                 let path = cache.join(&alias);
-                if path.is_dir() {
+                if path.is_dir() && path.read_dir()?.next().is_some() {
                     eprintln!("Updating meme repository {} ({})", alias, url);
                     git_ops::update_repo(&path)?;
                 } else {


### PR DESCRIPTION
We are on a mission to provide a painless meming experience written in Rust (tm). However, one common roadblock from creating great memes is jumping in too quickly without reading the documentation, which leads to an empty directory preventing us from making memes when we eventually run `update-sources`. This PR fixes the issue, allowing our memes not be just dreams!

Fixes https://github.com/TheRawMeatball/meme-cli/issues/1