### PR TITLE
Add QOI support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ structopt = "0.3.25"
 memeinator = { path = "memeinator", version = "0.1.0" }
 anyhow = "1.0.47"
 image = "0.23"
+libqoi = "0.2.1"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard = "2"


### PR DESCRIPTION
QOI is a very fast image format which can often beat PNG on compression ratio. It is also very simple, having a [one page specification](https://qoiformat.org/qoi-specification.pdf)

This pull request uses [libqoi](https://crates.io/crates/libqoi) to encode the format, which has zero dependencies (other than std), so it wont add much to compile time.
